### PR TITLE
Implement Environment relationship

### DIFF
--- a/asyncssh_plugin/tasks.py
+++ b/asyncssh_plugin/tasks.py
@@ -133,7 +133,7 @@ async def create(node, inputs):
         'password': node.properties.get('password'),
         'private_key': node.runtime_properties[
             'ssh_keypair']['private_key_content'],
-        'env': node.properties.get('environment', {})
+        'env': node.runtime_properties.get('environment', {})
     })
 
 
@@ -199,3 +199,22 @@ async def delete(node, inputs):
                              .format(node.name))
     if 'ssh' in node.runtime_properties:
         del node.runtime_properties['ssh']
+
+
+@utils.operation
+async def inject(source, target, inputs):
+    source.context.logger.info('[{0} -----> {1}] Setting up '
+                               'environment using '
+                               'target node properties.'
+                               .format(target.name, source.name))
+    env = source.runtime_properties.get('environment', {})
+    env.update(target.properties)
+    source.update_runtime_properties('environment', env)
+
+
+@utils.operation
+async def eject(source, target, inputs):
+    source.context.logger.info('[{0} --X--> {1}] Destroying environment.'
+                               .format(target.name, source.name))
+    if 'environment' in source.runtime_properties:
+        del source.runtime_properties['environment']

--- a/asyncssh_plugin/tests/templates/aiorchestra-software-config.yaml
+++ b/asyncssh_plugin/tests/templates/aiorchestra-software-config.yaml
@@ -40,6 +40,22 @@ node_types:
         unlink:
           implementation: asyncssh_plugin.tests.plugin:eject_host_and_key
 
+  software_configuration_environment:
+    derived_from: tosca.nodes.Root
+    properties:
+      my_own_var:
+        type: string
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation: aiorchestra.core.noop:noop
+        start:
+          implementation: aiorchestra.core.noop:noop
+        stop:
+          implementation: aiorchestra.core.noop:noop
+        delete:
+          implementation: aiorchestra.core.noop:noop
 
 topology_template:
 #####################################################################
@@ -69,6 +85,11 @@ topology_template:
     relationship_stab:
       type: tosca.aiorchestra.node
 
+    orchestra_software_configuration_environment:
+      type: software_configuration_environment
+      properties:
+        my_own_var: 'Hello'
+
     orchestra_software_configuration_script:
       type: tosca.asyncssh.software_configuration.script
       properties:
@@ -76,9 +97,8 @@ topology_template:
         port: { get_input: ssh_port }
         install_script: { get_input: install_script }
         uninstall_script: { get_input: uninstall_script }
-        environment:
-          my_own_var: 'Adele: Hello from the other side!'
       requirements:
+        - environment: orchestra_software_configuration_environment
         - host_and_key:
             node: relationship_stab
             relationship: test.asyncssh.plugin.inject_host_key

--- a/examples/orchestra-asyncssh-docker-software-configuration.yaml
+++ b/examples/orchestra-asyncssh-docker-software-configuration.yaml
@@ -12,11 +12,42 @@ imports:
   - ../types.yaml
   - https://raw.githubusercontent.com/aiorchestra/aiorchestra-openstack-plugin/master/types.yaml
 
+#####################################################################
+# Node types
+#####################################################################
+
+node_types:
+
+  software_configuration_environment:
+    derived_from: tosca.nodes.Root
+    properties:
+      my_own_var:
+        type: string
+      my_own_another_var:
+        type: integer
+      ssh_private_key:
+        type: string
+      ssh_public_key:
+        type: string
+      floating_ip:
+        type: string
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation: aiorchestra.core.noop:noop
+        start:
+          implementation: aiorchestra.core.noop:noop
+        stop:
+          implementation: aiorchestra.core.noop:noop
+        delete:
+          implementation: aiorchestra.core.noop:noop
+
+#####################################################################
+# Topology
+#####################################################################
 
 topology_template:
-#####################################################################
-# Inputs
-#####################################################################
 
   inputs:
 
@@ -206,16 +237,31 @@ topology_template:
             node: orchestra_subnet_port_one
             relationship: tosca.openstack.compute.connect_port_to_compute
 
+    orchestra_software_configuration_environment:
+      type: software_configuration_environment
+      properties:
+        my_own_var: 'Hello'
+        my_own_another_var: 1
+        ssh_private_key: { get_attribute: [orchestra_keypair, private_key_content] }
+        ssh_public_key: { get_attribute: [orchestra_keypair, public_key] }
+        floating_ip: { get_attribute: [orchestra_floating_ip_one, floating_ip_address] }
+      requirements:
+        - ssh:
+            node: orchestra_keypair
+            relationship: tosca.relationships.DependsOn
+        - floating_ip:
+            node: orchestra_floating_ip_one
+            relationship: tosca.relationships.DependsOn
+
     orchestra_software_configuration.docker:
       type: tosca.asyncssh.software_configuration.script
       properties:
         username: { get_input: username }
         port: { get_input: ssh_port }
         install_script: { get_input: install_script }
-        environment:
-          my_own_var: 'Adele: Hello from the other side!'
       requirements:
         - compute: orchestra_compute
+        - environment: orchestra_software_configuration_environment
         - ip:
             node: orchestra_floating_ip_one
             relationship: tosca.openstack.access_and_security.floating_provider

--- a/types.yaml
+++ b/types.yaml
@@ -3,20 +3,20 @@ tosca_definitions_version: tosca_simple_yaml_1_0
 node_types:
 
 ##################################################################################################
-# AsyncSSH base node types
+# AsyncSSH relationship type
 ##################################################################################################
 
-  tosca.asyncssh.relationships.node:
+  tosca.asyncssh.software_configuration.inject_environment:
     derived_from: tosca.relationships.Root
     interfaces:
       Configure:
         type: tosca.interfaces.relationship.Configure
         link:
-          implementation: aiorchestra.core.noop:link
+          implementation: asyncssh_plugin.tasks:inject
           inputs:
             type: map
         unlink:
-          implementation: aiorchestra.core.noop:unlink
+          implementation: asyncssh_plugin.tasks:eject
           inputs:
             type: map
 
@@ -45,14 +45,14 @@ node_types:
         type: string
         required: false
         default: ''
-      environment:
-        type: map
-        required: false
-        default: {}
     requirements:
       - compute:
           node: tosca.nodes.Root
           relationship: tosca.relationships.DependsOn
+          occurrences: [0, 1]
+      - environment:
+          node: tosca.nodes.Root
+          relationship: tosca.asyncssh.software_configuration.inject_environment
           occurrences: [0, 1]
     interfaces:
       Standard:


### PR DESCRIPTION
 No need to define almost empty type,
 so it was decided to define only
 relationship with underlaying implementation.

 Example included.
 Integration test was adjusted.

 Implements: #8
